### PR TITLE
better handling for code snippets

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,8 +54,7 @@ module.exports = function(options) {
     str = str.replace(d_match[0], details);
     
     // Handle code snippets, so multiline snippets are treated nicely in GH
-    var gh_code_pattern = '```';
-    str =  str.replace(/`/g, gh_code_pattern);
+    str =  str.replace(/^`\n/gm, '```\n');
 
     // Get plugin name.
     var n_match = str.match(/^#([^#]+)#[\\s ]*?$/im);

--- a/index.js
+++ b/index.js
@@ -52,6 +52,10 @@ module.exports = function(options) {
     var d_match = str.match(/^([^#]+)##/mg);
     var details = d_match[0].replace(/^([^:\r\n]+):\s*(.+)\n|\r/gim, details_pattern);
     str = str.replace(d_match[0], details);
+    
+    // Handle code snippets, so multiline snippets are treated nicely in GH
+    var gh_code_pattern = '```';
+    str =  str.replace(/`/g, gh_code_pattern);
 
     // Get plugin name.
     var n_match = str.match(/^#([^#]+)#[\\s ]*?$/im);


### PR DESCRIPTION
Better to use fence blocks in the github readme, so if the user created a multiline code snippet it would now work both in WP and in GH.
